### PR TITLE
[TH2-5265] fixed: codec can't encode fields with type `LocalDateTime`, `LocalDate`, `LocalTime` and value with timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# th2-codec-fix-ng 0.1.1
+# th2-codec-fix-ng 0.1.2
 
 This codec can be used in dirty mode for decoding and encoding messages via the FIX protocol.
 
@@ -46,6 +46,10 @@ default value: `true`. If `true`, decodes `components` to nested maps instead of
 Component benchmark results available [here](docs/benchmarks/jmh-benchmark.md).
 
 ## Release notes
+
+### 0.1.2
+  + fixed: codec can't encode fields with type `LocalDateTime`, `LocalDate`, `LocalTime` and value with timezone 
+  + Updated sailfish: `3.4.260`
 
 ### 0.1.1
   + `decodeDelimiter` setting option added.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 kotlin_version=1.8.22
-release_version=0.1.1
+release_version=0.1.2
 
 vcs_url=https://github.com/th2-net/th2-codec-fix-ng

--- a/src/main/kotlin/com/exactpro/th2/codec/fixng/FixNgCodec.kt
+++ b/src/main/kotlin/com/exactpro/th2/codec/fixng/FixNgCodec.kt
@@ -23,6 +23,7 @@ import com.exactpro.sf.common.messages.structures.IDictionaryStructure
 import com.exactpro.sf.common.messages.structures.IFieldStructure
 import com.exactpro.sf.common.messages.structures.IMessageStructure
 import com.exactpro.sf.common.messages.structures.StructureUtils
+import com.exactpro.sf.comparison.conversion.MultiConverter
 import com.exactpro.th2.codec.api.IPipelineCodec
 import com.exactpro.th2.codec.api.IReportingContext
 import com.exactpro.th2.codec.fixng.FixNgCodecFactory.Companion.PROTOCOL
@@ -356,9 +357,9 @@ class FixNgCodec(dictionary: IDictionaryStructure, settings: FixNgCodecSettings)
                     value is String -> {
                         try {
                             when (field.primitiveType) {
-                                LocalDateTime::class.java -> LocalDateTime.parse(value)
-                                LocalDate::class.java -> LocalDate.parse(value)
-                                LocalTime::class.java -> LocalTime.parse(value)
+                                LocalDateTime::class.java -> MultiConverter.convert<LocalDateTime>(value, LocalDateTime::class.java)
+                                LocalDate::class.java -> MultiConverter.convert<LocalDate>(value, LocalDate::class.java)
+                                LocalTime::class.java -> MultiConverter.convert<LocalTime>(value, LocalTime::class.java)
                                 java.lang.Boolean::class.java -> when {
                                     value.equals("true", true) -> true
                                     value.equals("false", true) -> false

--- a/src/test/kotlin/com/exactpro/th2/codec/fixng/FixNgCodecTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/codec/fixng/FixNgCodecTest.kt
@@ -534,6 +534,15 @@ class FixNgCodecTest {
         expectedMessage = parsedMessageWithNestedGroups
     )
 
+    @ParameterizedTest
+    @MethodSource("configs")
+    fun `encode time zone`(isDirty: Boolean, delimiter: Char) = encodeTest(
+        MSG_TIME_ZONE,
+        isDirty,
+        delimiter,
+        parsedMessage = parsedMessageWithTimezone
+    )
+
     private fun createCodec(delimiter: Char = '', decodeValuesToStrings: Boolean = false): FixNgCodec {
         return FixNgCodec(dictionary, FixNgCodecSettings(
             dictionary = "",
@@ -873,6 +882,31 @@ class FixNgCodecTest {
         )
     )
 
+    private val parsedMessageWithTimezone = ParsedMessage(
+        MessageId("test_alias", Direction.OUTGOING, 0L, Instant.now(), emptyList()),
+        EventId("test_id", "test_book", "test_scope", Instant.now()),
+        "TimeZoneTestMessage",
+        mutableMapOf("encode-mode" to "dirty"),
+        PROTOCOL,
+        mutableMapOf(
+            "header" to mutableMapOf(
+                "MsgSeqNum" to 10947,
+                "SenderCompID" to "SENDER",
+                "SendingTime" to "2023-04-19T10:36:07.415088Z",
+                "TargetCompID" to "RECEIVER",
+                "BeginString" to "FIXT.1.1",
+                "BodyLength" to 295,
+                "MsgType" to "TEST_4"
+            ),
+            "TransactTime" to "2018-02-05T10:38:08.000008Z",
+            "TotalVolumeTradedDate" to "2018-02-05Z",
+            "TotalVolumeTradedTime" to "10:38:08.000008Z",
+            "trailer" to mutableMapOf(
+                "CheckSum" to "122"
+            )
+        )
+    )
+
     companion object {
         private const val DIRTY_MODE_WARNING_PREFIX = "Dirty mode WARNING: "
 
@@ -902,6 +936,7 @@ class FixNgCodecTest {
         private const val MSG_NESTED_OPT_COMPONENTS_MISSED_ALL_OUTER_FIELDS_AND_REQ_INNER_FIELD = "8=FIXT.1.19=5935=TEST_249=MZHOT056=INET34=12558=text_110=191"
 
         private const val MSG_NESTED_GROUPS = "8=FIXT.1.19=8835=TEST_349=MZHOT056=INET34=12573=2398=3399=1399=2399=3398=3399=3399=2399=110=211"
+        private const val MSG_TIME_ZONE = "8=FIXT.1.19=12335=TEST_449=SENDER56=RECEIVER34=1094752=20230419-10:36:07.41508860=20180205-10:38:08.000008449=20180205450=10:38:0810=206"
 
         @JvmStatic
         fun configs() = listOf(

--- a/src/test/resources/dictionary.xml
+++ b/src/test/resources/dictionary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
-  ~ Copyright 2023 Exactpro (Exactpro Systems Limited)
+  ~ Copyright 2023-2024 Exactpro (Exactpro Systems Limited)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -7384,6 +7384,14 @@
             <attribute name="IsAdmin" type="java.lang.Boolean">false</attribute>
             <attribute name="MessageType" type="java.lang.String">TEST_3</attribute>
             <field name="OuterGroup" reference="component-OuterGroup"/>
+        </message>
+        <message name="TimeZoneTestMessage">
+            <attribute name="entity_type" type="java.lang.String">Message</attribute>
+            <attribute name="IsAdmin" type="java.lang.Boolean">false</attribute>
+            <attribute name="MessageType" type="java.lang.String">TEST_4</attribute>
+            <field name="TransactTime" reference="field-TransactTime" required="true"/>
+            <field name="TotalVolumeTradedDate" reference="field-TotalVolumeTradedDate" required="true"/>
+            <field name="TotalVolumeTradedTime" reference="field-TotalVolumeTradedTime" required="true"/>
         </message>
         <message id="component-OuterComponent" name="OuterComponent">
             <attribute name="entity_type" type="java.lang.String">Component</attribute>


### PR DESCRIPTION
* Updated sailfish: `3.4.260`